### PR TITLE
Ubuntu compatibility and (partially) rootless configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/mon/node_modules/
 *.o
 *.so
 package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "cpp-btree"]
 	path = cpp-btree
-	url = ../cpp-btree.git
+	url = ../../vitalif/cpp-btree.git
 [submodule "json11"]
 	path = json11
-	url = ../json11.git
+	url = ../../vitalif/json11.git

--- a/mon/mon.js
+++ b/mon/mon.js
@@ -530,23 +530,23 @@ class Mon
             {
                 const timer_id = setTimeout(() =>
                 {
-                    this.ws.close();
-                    this.ws = null;
+                    //this.ws.close();
+                    //this.ws = null;
                     ok(false);
                 }, this.config.etcd_mon_timeout);
-                this.ws = new WebSocket(base+'/watch');
+                //this.ws = new WebSocket(base+'/watch');
                 const fail = () =>
                 {
                     ok(false);
                 };
-                this.ws.on('error', fail);
-                this.ws.on('open', () =>
-                {
-                    this.ws.removeListener('error', fail);
-                    if (timer_id)
-                        clearTimeout(timer_id);
-                    ok(true);
-                });
+                //this.ws.on('error', fail);
+                //this.ws.on('open', () =>
+                //{
+                //    this.ws.removeListener('error', fail);
+                //    if (timer_id)
+                //        clearTimeout(timer_id);
+                //    ok(true);
+                //});
             });
             if (ok)
                 break;
@@ -555,10 +555,10 @@ class Mon
             this.ws = null;
             retry++;
         }
-        if (!this.ws)
-        {
-            this.die('Failed to open etcd watch websocket');
-        }
+        //if (!this.ws)
+        //{
+        //    this.die('Failed to open etcd watch websocket');
+        //}
         const cur_addr = this.selected_etcd_url;
         this.ws_alive = true;
         this.ws_keepalive_timer = setInterval(() =>
@@ -566,7 +566,7 @@ class Mon
             if (this.ws_alive)
             {
                 this.ws_alive = false;
-                this.ws.send(JSON.stringify({ progress_request: {} }));
+                //this.ws.send(JSON.stringify({ progress_request: {} }));
             }
             else
             {
@@ -574,90 +574,90 @@ class Mon
                 this.restart_watcher(cur_addr);
             }
         }, (Number(this.config.etcd_keepalive_interval) || 30)*1000);
-        this.ws.on('error', () => this.restart_watcher(cur_addr));
-        this.ws.send(JSON.stringify({
-            create_request: {
-                key: b64(this.etcd_prefix+'/'),
-                range_end: b64(this.etcd_prefix+'0'),
-                start_revision: ''+this.etcd_watch_revision,
-                watch_id: 1,
-                progress_notify: true,
-            },
-        }));
-        this.ws.on('message', (msg) =>
-        {
-            this.ws_alive = true;
-            let data;
-            try
-            {
-                data = JSON.parse(msg);
-            }
-            catch (e)
-            {
-            }
-            if (!data || !data.result)
-            {
-                console.error('Unknown message received from watch websocket: '+msg);
-            }
-            else if (data.result.canceled)
-            {
-                // etcd watch canceled
-                if (data.result.compact_revision)
-                {
-                    // we may miss events if we proceed
-                    console.error('Revisions before '+data.result.compact_revision+' were compacted by etcd, exiting');
-                    this.on_stop(1);
-                }
-                console.error('Watch canceled by etcd, reason: '+data.result.cancel_reason+', exiting');
-                this.on_stop(1);
-            }
-            else if (data.result.created)
-            {
-                // etcd watch created
-            }
-            else
-            {
-                let stats_changed = false, changed = false, pg_states_changed = false;
-                if (this.verbose)
-                {
-                    console.log('Revision '+data.result.header.revision+' events: ');
-                }
-                this.etcd_watch_revision = BigInt(data.result.header.revision)+BigInt(1);
-                for (const e of data.result.events||[])
-                {
-                    this.parse_kv(e.kv);
-                    const key = e.kv.key.substr(this.etcd_prefix.length);
-                    if (key.substr(0, 11) == '/osd/stats/' || key.substr(0, 10) == '/pg/stats/' || key.substr(0, 16) == '/osd/inodestats/')
-                    {
-                        stats_changed = true;
-                    }
-                    else if (key.substr(0, 10) == '/pg/state/')
-                    {
-                        pg_states_changed = true;
-                    }
-                    else if (key != '/stats' && key.substr(0, 13) != '/inode/stats/')
-                    {
-                        changed = true;
-                    }
-                    if (this.verbose)
-                    {
-                        console.log(JSON.stringify(e));
-                    }
-                }
-                if (pg_states_changed)
-                {
-                    this.save_last_clean().catch(this.die);
-                }
-                if (stats_changed)
-                {
-                    this.schedule_update_stats();
-                }
-                if (changed)
-                {
-                    this.schedule_recheck();
-                }
-            }
-        });
+        //this.ws.on('error', () => this.restart_watcher(cur_addr));
+        //this.ws.send(JSON.stringify({
+        //    create_request: {
+        //        key: b64(this.etcd_prefix+'/'),
+        //        range_end: b64(this.etcd_prefix+'0'),
+        //        start_revision: ''+this.etcd_watch_revision,
+        //        watch_id: 1,
+        //        progress_notify: true,
+        //    },
+        //}));
+        //this.ws.on('message', (msg) =>
+        //{
+        //    this.ws_alive = true;
+        //    let data;
+        //    try
+        //    {
+        //        data = JSON.parse(msg);
+        //    }
+        //    catch (e)
+        //    {
+        //    }
+        //    if (!data || !data.result)
+        //    {
+        //        console.error('Unknown message received from watch websocket: '+msg);
+        //    }
+        //    else if (data.result.canceled)
+        //    {
+        //        // etcd watch canceled
+        //        if (data.result.compact_revision)
+        //        {
+        //            // we may miss events if we proceed
+        //            console.error('Revisions before '+data.result.compact_revision+' were compacted by etcd, exiting');
+        //            this.on_stop(1);
+        //        }
+        //        console.error('Watch canceled by etcd, reason: '+data.result.cancel_reason+', exiting');
+        //        this.on_stop(1);
+        //    }
+        //    else if (data.result.created)
+        //    {
+        //        // etcd watch created
+        //    }
+        //    else
+        //    {
+        //        let stats_changed = false, changed = false, pg_states_changed = false;
+        //        if (this.verbose)
+        //        {
+        //            console.log('Revision '+data.result.header.revision+' events: ');
+        //        }
+        //        this.etcd_watch_revision = BigInt(data.result.header.revision)+BigInt(1);
+        //        for (const e of data.result.events||[])
+        //        {
+        //            this.parse_kv(e.kv);
+        //            const key = e.kv.key.substr(this.etcd_prefix.length);
+        //            if (key.substr(0, 11) == '/osd/stats/' || key.substr(0, 10) == '/pg/stats/' || key.substr(0, 16) == '/osd/inodestats/')
+        //            {
+        //                stats_changed = true;
+        //            }
+        //            else if (key.substr(0, 10) == '/pg/state/')
+        //            {
+        //                pg_states_changed = true;
+        //            }
+        //            else if (key != '/stats' && key.substr(0, 13) != '/inode/stats/')
+        //            {
+        //                changed = true;
+        //            }
+        //            if (this.verbose)
+        //            {
+        //                console.log(JSON.stringify(e));
+        //            }
+        //        }
+        //        if (pg_states_changed)
+        //        {
+        //            this.save_last_clean().catch(this.die);
+        //        }
+        //        if (stats_changed)
+        //        {
+        //            this.schedule_update_stats();
+        //        }
+        //        if (changed)
+        //        {
+        //            this.schedule_recheck();
+        //        }
+        //    }
+        //});
     }
 
     async save_last_clean()

--- a/mon/mon.js
+++ b/mon/mon.js
@@ -748,7 +748,7 @@ class Mon
         while (1)
         {
             const res = await this.etcd_call('/kv/txn', {
-                compare: [ { target: 'CREATE', create_revision: 0, key: b64(this.etcd_prefix+'/mon/master') } ],
+                compare: [ { target: 1 /*CREATE*/, create_revision: 0, key: b64(this.etcd_prefix+'/mon/master') } ],
                 success: [ { requestPut: { key: b64(this.etcd_prefix+'/mon/master'), value: b64(JSON.stringify(state)), lease: ''+this.etcd_lease_id } } ],
             }, this.etcd_start_timeout, 0);
             if (res.succeeded)
@@ -892,12 +892,12 @@ class Mon
             for (const osd_num of this.all_osds())
             {
                 const key = b64(this.etcd_prefix+'/osd/state/'+osd_num);
-                checks.push({ key, target: 'MOD', result: 'LESS', mod_revision: ''+this.etcd_watch_revision });
+                checks.push({ key, target: 2 /*MOD*/, result: 2 /*LESS*/, mod_revision: ''+this.etcd_watch_revision });
             }
             const res = await this.etcd_call('/kv/txn', {
                 compare: [
-                    { key: b64(this.etcd_prefix+'/mon/master'), target: 'LEASE', lease: ''+this.etcd_lease_id },
-                    { key: b64(this.etcd_prefix+'/config/pgs'), target: 'MOD', mod_revision: ''+this.etcd_watch_revision, result: 'LESS' },
+                    { key: b64(this.etcd_prefix+'/mon/master'), target: 4 /*LEASE*/, lease: ''+this.etcd_lease_id },
+                    { key: b64(this.etcd_prefix+'/config/pgs'), target: 2 /*MOD*/, mod_revision: ''+this.etcd_watch_revision, result: 2 /*LESS*/ },
                     ...checks,
                 ],
                 success: [
@@ -983,9 +983,9 @@ class Mon
             // Sooo we probably want to change our storage scheme for PG histories...
             request.compare.push({
                 key: b64(this.etcd_prefix+'/pg/history/'+pool_id+'/'+(i+1)),
-                target: 'MOD',
+                target: 2 /*MOD*/,
                 mod_revision: ''+this.etcd_watch_revision,
-                result: 'LESS',
+                result: 2 /*LESS*/,
             });
             if (pg_history[i])
             {
@@ -1330,8 +1330,8 @@ class Mon
     async save_pg_config(etcd_request = { compare: [], success: [] })
     {
         etcd_request.compare.push(
-            { key: b64(this.etcd_prefix+'/mon/master'), target: 'LEASE', lease: ''+this.etcd_lease_id },
-            { key: b64(this.etcd_prefix+'/config/pgs'), target: 'MOD', mod_revision: ''+this.etcd_watch_revision, result: 'LESS' },
+            { key: b64(this.etcd_prefix+'/mon/master'), target: 4 /*LEASE*/, lease: ''+this.etcd_lease_id },
+            { key: b64(this.etcd_prefix+'/config/pgs'), target: 2 /*MOD*/, mod_revision: ''+this.etcd_watch_revision, result: 2 /*LESS*/ },
         );
         etcd_request.success.push(
             { requestPut: { key: b64(this.etcd_prefix+'/config/pgs'), value: b64(JSON.stringify(this.state.config.pgs)) } },

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,18 @@ project(vitastor)
 include(GNUInstallDirs)
 include(CTest)
 
+include (FetchContent)
+set (BOOST_INCLUDE_LIBRARIES "json")
+FetchContent_Declare (boost URL "https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.xz" URL_MD5 "6cf0cdd797bca685910d527ae3c08cb3")
+FetchContent_MakeAvailable (boost)
+include_directories ("${boost_assert_SOURCE_DIR}/include")
+include_directories ("${boost_config_SOURCE_DIR}/include")
+include_directories ("${boost_core_SOURCE_DIR}/include")
+include_directories ("${boost_json_SOURCE_DIR}/include")
+include_directories ("${boost_throw_exception_SOURCE_DIR}/include")
+include_directories ("${boost_system_SOURCE_DIR}/include")
+include_directories ("${boost_variant2_SOURCE_DIR}/include")
+
 set(WITH_QEMU false CACHE BOOL "Build QEMU driver inside Vitastor source tree")
 set(WITH_FIO true CACHE BOOL "Build FIO driver")
 set(QEMU_PLUGINDIR qemu CACHE STRING "QEMU plugin directory suffix (qemu-kvm on RHEL)")
@@ -209,6 +221,7 @@ add_executable(vitastor-disk
 )
 target_link_libraries(vitastor-disk
 	tcmalloc_minimal
+    boost_json
 	${LIBURING_LIBRARIES}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ project(vitastor)
 include(GNUInstallDirs)
 include(CTest)
 
+set (CMAKE_CXX_STANDARD 17)
 include (FetchContent)
 set (BOOST_INCLUDE_LIBRARIES "json")
 FetchContent_Declare (boost URL "https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.xz" URL_MD5 "6cf0cdd797bca685910d527ae3c08cb3")

--- a/src/disk_tool.h
+++ b/src/disk_tool.h
@@ -119,7 +119,9 @@ struct disk_tool_t
     int prepare(std::vector<std::string> devices);
     std::vector<vitastor_dev_info_t> collect_devices(const std::vector<std::string> & devices);
     json11::Json add_partitions(vitastor_dev_info_t & devinfo, std::vector<std::string> sizes);
-    std::vector<std::string> get_new_data_parts(vitastor_dev_info_t & dev, uint64_t osd_per_disk, uint64_t max_other_percent);
+
+    /// Returns vector of `(node, uuid)`.
+    std::vector<std::pair<std::string, std::string>> get_new_data_parts(vitastor_dev_info_t & dev, uint64_t osd_per_disk, uint64_t max_other_percent);
     int get_meta_partition(std::vector<vitastor_dev_info_t> & ssds, std::map<std::string, std::string> & options);
 
     int upgrade_simple_unit(std::string unit);
@@ -133,6 +135,7 @@ std::string realpath_str(std::string path, bool nofail = true);
 std::string read_all_fd(int fd);
 std::string read_file(std::string file, bool allow_enoent = false);
 int disable_cache(std::string dev);
+int disable_cache_by_parent_device(std::string parent_dev, std::string dev);
 std::string get_parent_device(std::string dev);
 bool json_is_true(const json11::Json & val);
 int shell_exec(const std::vector<std::string> & cmd, const std::string & in, std::string *out, std::string *err);

--- a/src/disk_tool_prepare.cpp
+++ b/src/disk_tool_prepare.cpp
@@ -582,21 +582,7 @@ int disk_tool_t::prepare(std::vector<std::string> devices)
             for (const auto & uuid: get_new_data_parts(dev, osd_per_disk, max_other_percent))
             {
                 options["force"] = true;
-                /// There are only few partitions here, or even one, no reason to make it `O(1)`.
-                bool found = false;
-                for (const auto & partition : dev.pt["partitions"].array_items())
-                {
-                    if (partition["uuid"] == uuid)
-                    {
-                        options["data_device"] = partition["node"].string_value();
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
-                {
-                    throw std::runtime_error("Could not find partition " + uuid);
-                }
+                options["data_device"] = "/dev/disk/by-partuuid/"+strtolower(uuid);
                 if (hybrid)
                 {
                     // Select/create journal and metadata partitions

--- a/src/disk_tool_prepare.cpp
+++ b/src/disk_tool_prepare.cpp
@@ -582,7 +582,21 @@ int disk_tool_t::prepare(std::vector<std::string> devices)
             for (const auto & uuid: get_new_data_parts(dev, osd_per_disk, max_other_percent))
             {
                 options["force"] = true;
-                options["data_device"] = "/dev/disk/by-partuuid/"+strtolower(uuid);
+                /// There are only few partitions here, or even one, no reason to make it `O(1)`.
+                bool found = false;
+                for (const auto & partition : dev.pt["partitions"].array_items())
+                {
+                    if (partition["uuid"] == uuid)
+                    {
+                        options["data_device"] = partition["node"].string_value();
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    throw std::runtime_error("Could not find partition " + uuid);
+                }
                 if (hybrid)
                 {
                     // Select/create journal and metadata partitions

--- a/src/disk_tool_prepare.cpp
+++ b/src/disk_tool_prepare.cpp
@@ -379,33 +379,6 @@ json11::Json disk_tool_t::add_partitions(vitastor_dev_info_t & devinfo, std::vec
         }
         break;
     }
-    // Wait until device symlinks in /dev/disk/by-partuuid/ appear
-    bool exists = false;
-    iter = 0;
-    while (!exists && iter < 300) // max 30 sec
-    {
-        exists = true;
-        for (const auto & part: new_parts)
-        {
-            std::string link_path = "/dev/disk/by-partuuid/"+strtolower(part["uuid"].string_value());
-            struct stat st;
-            if (lstat(link_path.c_str(), &st) < 0)
-            {
-                if (errno == ENOENT)
-                    exists = false;
-                else
-                {
-                    fprintf(stderr, "Failed to lstat %s: %s\n", link_path.c_str(), strerror(errno));
-                    return {};
-                }
-            }
-        }
-        if (!exists)
-        {
-            struct timespec ts = { .tv_sec = 0, .tv_nsec = 100000000 }; // 100ms
-            iter += (nanosleep(&ts, NULL) == 0);
-        }
-    }
     devinfo.pt = newpt;
     devinfo.osd_part_count += sizes.size();
     devinfo.free = free_from_parttable(newpt);

--- a/src/disk_tool_prepare.cpp
+++ b/src/disk_tool_prepare.cpp
@@ -358,7 +358,7 @@ json11::Json disk_tool_t::add_partitions(vitastor_dev_info_t & devinfo, std::vec
                     iter++;
                     // Run partprobe
                     std::string out;
-                    if (iter > 1 || (r = shell_exec({ "partprobe", devinfo.path }, "", &out, NULL)) != 0)
+                    if (iter > 1 || (r = shell_exec({ "sudo", "partprobe", devinfo.path }, "", &out, NULL)) != 0)
                     {
                         fprintf(
                             stderr, iter == 1 && r == 255

--- a/src/disk_tool_utils.cpp
+++ b/src/disk_tool_utils.cpp
@@ -4,6 +4,9 @@
 #include <sys/wait.h>
 #include <dirent.h>
 
+#include <boost/json/parse.hpp>
+#include <boost/json/serialize.hpp>
+
 #include "disk_tool.h"
 #include "rw_blocking.h"
 #include "str_util.h"
@@ -316,6 +319,7 @@ json11::Json read_parttable(std::string dev)
     if (part_dump != "")
     {
         std::string err;
+        part_dump = boost::json::serialize(boost::json::parse(part_dump, {}, { .allow_trailing_commas = true }));
         pt = json11::Json::parse(part_dump, err);
         if (err != "")
         {

--- a/src/disk_tool_utils.cpp
+++ b/src/disk_tool_utils.cpp
@@ -305,10 +305,10 @@ int write_zero(int fd, uint64_t offset, uint64_t size)
 json11::Json read_parttable(std::string dev)
 {
     std::string part_dump;
-    int r = shell_exec({ "sfdisk", "--dump", dev, "--json" }, "", &part_dump, NULL);
+    int r = shell_exec({ "sfdisk", dev, "--json" }, "", &part_dump, NULL);
     if (r == 255)
     {
-        fprintf(stderr, "Error running sfdisk --dump %s --json\n", dev.c_str());
+        fprintf(stderr, "Error running sfdisk %s --json\n", dev.c_str());
         return json11::Json(false);
     }
     // Decode partition table
@@ -319,7 +319,7 @@ json11::Json read_parttable(std::string dev)
         pt = json11::Json::parse(part_dump, err);
         if (err != "")
         {
-            fprintf(stderr, "sfdisk --dump %s --json returned bad JSON: %s\n", dev.c_str(), part_dump.c_str());
+            fprintf(stderr, "sfdisk %s --json returned bad JSON: %s\n", dev.c_str(), part_dump.c_str());
             return json11::Json(false);
         }
         pt = pt["partitiontable"];

--- a/src/disk_tool_utils.cpp
+++ b/src/disk_tool_utils.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Vitaliy Filippov, 2019+
 // License: VNPL-1.1 (see README.md for details)
 
+#include <filesystem>
+
 #include <sys/wait.h>
 #include <dirent.h>
 
@@ -104,20 +106,18 @@ static int check_queue_cache(std::string dev, std::string parent_dev)
     return trim(r) == "write through" ? 0 : -1;
 }
 
-// returns 1 = warning, -1 = error, 0 = success
-int disable_cache(std::string dev)
+int disable_cache_impl(std::string parent_dev_name, std::string dev)
 {
-    auto parent_dev = get_parent_device(dev);
-    if (parent_dev == "")
+    if (parent_dev_name == "")
         return 1;
-    auto scsi_disk = "/sys/block/"+parent_dev+"/device/scsi_disk";
+    auto scsi_disk = "/sys/block/"+parent_dev_name+"/device/scsi_disk";
     DIR *dir = opendir(scsi_disk.c_str());
     if (!dir)
     {
         if (errno == ENOENT)
         {
             // Not a SCSI/SATA device, just check /sys/block/.../queue/write_cache
-            return check_queue_cache(dev.substr(5), parent_dev);
+            return check_queue_cache(dev.substr(5), parent_dev_name);
         }
         else
         {
@@ -134,7 +134,7 @@ int disable_cache(std::string dev)
         {
             // Not a SCSI/SATA device, just check /sys/block/.../queue/write_cache
             closedir(dir);
-            return check_queue_cache(dev.substr(5), parent_dev);
+            return check_queue_cache(dev.substr(5), parent_dev_name);
         }
         scsi_disk += "/";
         scsi_disk += de->d_name;
@@ -165,6 +165,18 @@ int disable_cache(std::string dev)
         }
     }
     return 0;
+}
+
+// returns 1 = warning, -1 = error, 0 = success
+int disable_cache(std::string dev)
+{
+    auto parent_dev_name = get_parent_device(dev);
+    return disable_cache_impl(parent_dev_name, dev);
+}
+
+int disable_cache_by_parent_device(std::string parent_dev, std::string dev)
+{
+    return disable_cache_impl(std::filesystem::path(parent_dev).filename().string(), dev);
 }
 
 std::string get_parent_device(std::string dev)

--- a/src/etcd_state_client.h
+++ b/src/etcd_state_client.h
@@ -114,6 +114,8 @@ public:
     std::map<inode_t, inode_config_t> inode_config;
     std::map<std::string, inode_t> inode_by_name;
 
+    std::map<unsigned, http_co_t *> watch_clients;
+
     std::function<void(std::map<std::string, etcd_kv_t> &)> on_change_hook;
     std::function<void(json11::Json::object &)> on_load_config_hook;
     std::function<json11::Json()> load_pgs_checks_hook;

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -95,15 +95,13 @@ http_co_t *http_init(timerfd_manager_t *tfd)
 http_co_t* open_websocket(timerfd_manager_t *tfd, const std::string & host, const std::string & path,
     int timeout, std::function<void(const http_response_t *msg)> response_callback)
 {
-    std::string request = "POST "+path+" HTTP/1.1\r\n"
+    std::string request = "GET "+path+" HTTP/1.1\r\n"
         "Host: "+host+"\r\n"
         "Upgrade: websocket\r\n"
         "Connection: upgrade\r\n"
-        "Content-Type: application/json\r\n"
-        "Content-Length: 2\r\n"
         "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n"
         "Sec-WebSocket-Version: 13\r\n"
-        "\r\n{}";
+        "\r\n";
     http_co_t *handler = new http_co_t();
     handler->tfd = tfd;
     handler->state = HTTP_CO_CLOSED;

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -95,13 +95,15 @@ http_co_t *http_init(timerfd_manager_t *tfd)
 http_co_t* open_websocket(timerfd_manager_t *tfd, const std::string & host, const std::string & path,
     int timeout, std::function<void(const http_response_t *msg)> response_callback)
 {
-    std::string request = "GET "+path+" HTTP/1.1\r\n"
+    std::string request = "POST "+path+" HTTP/1.1\r\n"
         "Host: "+host+"\r\n"
         "Upgrade: websocket\r\n"
         "Connection: upgrade\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: 2\r\n"
         "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n"
         "Sec-WebSocket-Version: 13\r\n"
-        "\r\n";
+        "\r\n{}";
     http_co_t *handler = new http_co_t();
     handler->tfd = tfd;
     handler->state = HTTP_CO_CLOSED;

--- a/src/messenger.h
+++ b/src/messenger.h
@@ -33,7 +33,7 @@
 #define PEER_RDMA 4
 #define PEER_STOPPED 5
 
-#define VITASTOR_CONFIG_PATH "/etc/vitastor/vitastor.conf"
+#define VITASTOR_CONFIG_PATH "./vitastor.conf"
 
 #define MSGR_SENDP_HDR 1
 #define MSGR_SENDP_FREE 2

--- a/src/nbd_proxy.cpp
+++ b/src/nbd_proxy.cpp
@@ -718,9 +718,7 @@ protected:
                 exit(1);
             }
             uint64_t handle = *((uint64_t*)cur_req.handle);
-#ifdef DEBUG
             printf("request %lx +%x %lx\n", be64toh(cur_req.from), be32toh(cur_req.len), handle);
-#endif
             void *buf = NULL;
             cluster_op_t *op = new cluster_op_t;
             if (req_type == NBD_CMD_READ || req_type == NBD_CMD_WRITE)
@@ -739,9 +737,7 @@ protected:
             }
             op->callback = [this, buf, handle](cluster_op_t *op)
             {
-#ifdef DEBUG
                 printf("reply %lx e=%d\n", handle, op->retval);
-#endif
                 nbd_reply *reply = (nbd_reply*)buf;
                 reply->magic = htobe32(NBD_REPLY_MAGIC);
                 memcpy(reply->handle, &handle, 8);

--- a/src/osd_cluster.cpp
+++ b/src/osd_cluster.cpp
@@ -559,7 +559,7 @@ json11::Json osd_t::on_load_pgs_checks_hook()
     assert(this->pgs.size() == 0);
     json11::Json::array checks = {
         json11::Json::object {
-            { "target", "LEASE" },
+            { "target", 4 /*LEASE*/ },
             { "lease", etcd_lease_id },
             { "key", base64_encode(st_cli.etcd_prefix+"/osd/state/"+std::to_string(osd_num)) },
         }
@@ -818,7 +818,7 @@ void osd_t::report_pg_states()
             // Check that the PG key does not exist
             // Failed check indicates an unsuccessful PG lock attempt in this case
             checks.push_back(json11::Json::object {
-                { "target", "VERSION" },
+                { "target", 0 /*VERSION*/ },
                 { "version", 0 },
                 { "key", state_key_base64 },
             });
@@ -827,7 +827,7 @@ void osd_t::report_pg_states()
         {
             // Check that the key is ours if it already exists
             checks.push_back(json11::Json::object {
-                { "target", "LEASE" },
+                { "target", 4 /*LEASE*/ },
                 { "lease", etcd_lease_id },
                 { "key", state_key_base64 },
             });


### PR DESCRIPTION
- [x] 1.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.640014 s, 1.6 GB/s
   sfdisk: mutually exclusive arguments: --list-free --json --dump
   Re-reading the partition table failed.: Permission denied
   sfdisk: mutually exclusive arguments: --list-free --json --dump
   Failed to add 1 partition(s) with sfdisk: new partitions not found in table
   ```

- [x] 2.
   ```
   $ PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   sfdisk /dev/ram0 --json returned bad JSON: {
      "partitiontable": {
         "label":"gpt",
         "id":"7E96FF48-05A0-5641-B1D7-C951DE6CB64A",
         "device":"/dev/ram0",
         "unit":"sectors",
         "firstlba":2048,
         "lastlba":1999966,
         "sectorsize":512,
      }
   }
   ```

- [x] 3.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.65319 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   ^C # 30 seconds delay.
   ```

- [x] 4.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.661493 s, 1.5 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Failed to resolve /dev/disk/by-partuuid/50efa3d2-e9ec-2f46-ab6f-e7878e7d072f: No such file or directory
    is outside /dev/
   Warning: disable_data_fsync is auto, but cache status check failed. Leaving fsync on
   Failed to open data device /dev/disk/by-partuuid/50efa3d2-e9ec-2f46-ab6f-e7878e7d072f: No such file or director
   ```

- [x] 5.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.64584 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Error: Partition(s) 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256 on /dev/ram0 have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.
   partprobe failed to re-read partition table while disk /dev/ram0 is in use
   ```

- [x] 6.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.661189 s, 1.5 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   etcd_address is missing in Vitastor configuration
   ```

- [x] 7.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.646515 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Error reading OSD configuration from etcd: HTTP 404 Not body: 404 page not found
   Error reading OSD configuration from etcd: HTTP 404 Not body: 404 page not found
   Error reading OSD configuration from etcd: HTTP 404 Not body: 404 page not found
   ^C
   ```

- [x] 8.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.645847 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Error reading OSD configuration from etcd: Response has neither Connection: close, nor Transfer-Encoding: chunked nor Content-Length headers
   Error reading OSD configuration from etcd: Response has neither Connection: close, nor Transfer-Encoding: chunked nor Content-Length headers
   Error reading OSD configuration from etcd: Response has neither Connection: close, nor Transfer-Encoding: chunked nor Content-Length headers
   ^C
   ```

- [x] 9.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.644253 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Bad JSON in etcd event: expected value, got 'M' (77), ignoring event
   Disconnected from etcd 127.0.0.1:2379/v3alpha
   Could not create OSD. vitastor-cli alloc-osd didn't return a valid OSD number:
   ```

- [x] 10.
   ```
   $ dd if=/dev/zero of=/dev/ram0 bs=1M ; PATH=.:$PATH ./vitastor-disk prepare /dev/ram0
   dd: error writing '/dev/ram0': No space left on device
   977+0 records in
   976+0 records out
   1024000000 bytes (1.0 GB, 977 MiB) copied, 0.640043 s, 1.6 GB/s
   sfdisk: /dev/ram0: does not contain a recognized partition table
   Re-reading the partition table failed.: Permission denied
   Bad JSON in etcd event: expected value, got 'M' (77), ignoring event
   Disconnected from etcd 127.0.0.1:2379/v3alpha
   Initialized OSD 1 on /dev/ram0p1
   < Cancel >
   Failed to enable unit: Access denied
   Failed to enable systemd unit vitastor-osd@2
   ```

- [x] 11.
   ```
   $ PATH=.:$PATH ./vitastor-disk exec-osd /dev/ram0p1
   No RDMA devices found
   [OSD 5] Couldn't initialize RDMA, proceeding with TCP only
   Reading blockstore metadata
   Metadata entries loaded: 0, free blocks: 7546 / 7546
   Reading blockstore journal
   [OSD 5] reporting to etcd at ["http://127.0.0.1:2379/v3alpha"] every 5 seconds
   Journal entries loaded: 0, free journal space: 33550336 bytes (00001000..00001000 is used), free blocks: 7546 / 7546
   Warning: etcd request failed: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}, retrying 5 more times
   Warning: etcd request failed: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}, retrying 4 more times
   Warning: etcd request failed: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}, retrying 3 more times
   Warning: etcd request failed: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}, retrying 2 more times
   Warning: etcd request failed: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}, retrying 1 more times
   Error loading PGs from etcd: HTTP 400 Bad body: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}
   ```

- [x] 12.
   ```
   $ PATH=.:$PATH ./vitastor-disk exec-osd /dev/ram0p1
   No RDMA devices found
   [OSD 5] Couldn't initialize RDMA, proceeding with TCP only
   Reading blockstore metadata
   Metadata entries loaded: 0, free blocks: 7546 / 7546
   Reading blockstore journal
   [OSD 5] reporting to etcd at ["http://127.0.0.1:2379/v3alpha"] every 5 seconds
   Journal entries loaded: 0, free journal space: 33550336 bytes (00001000..00001000 is used), free blocks: 7546 / 7546
   Bad JSON in etcd event: expected value, got 'M' (77), ignoring event
   Disconnected from etcd 127.0.0.1:2379/v3alpha
   Bad JSON in etcd event: expected value, got 'M' (77), ignoring event
   Disconnected from etcd 127.0.0.1:2379/v3alpha
   ^C[OSD 5] Force stopping
   ```

- [x] 13.
   ```
   $ PATH=.:$PATH ./vitastor-disk exec-osd /dev/ram1p1
   No RDMA devices found
   [OSD 2] Couldn't initialize RDMA, proceeding with TCP only
   Reading blockstore metadata
   Metadata entries loaded: 0, free blocks: 7546 / 7546
   Reading blockstore journal
   [OSD 2] reporting to etcd at ["http://127.0.0.1:2379/v3alpha"] every 5 seconds
   Journal entries loaded: 0, free journal space: 33550336 bytes (00001000..00001000 is used), free blocks: 7546 / 7546
   Websocket ping failed, disconnecting from etcd 127.0.0.1:2379/v3alpha
   Websocket ping failed, disconnecting from etcd 127.0.0.1:2379/v3alpha
   Websocket ping failed, disconnecting from etcd 127.0.0.1:2379/v3alpha
   ^C[OSD 2] Force stopping
   ```

- [ ] 14.
   ```
   $ fio -thread -ioengine=./libfio_vitastor.so -name=test -bs=4M -direct=1 -iodepth=16 -rw=write -etcd=10.115.0.10:2379/v3alpha -image=testimg
   test: (g=0): rw=write, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=vitastor_cluster, iodepth=16
   fio-3.16
   Starting 1 thread
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   ^C
   fio: terminating on signal 2
   Error reading OSD configuration from etcd: HTTP request timed out
   ^C
   fio: terminating on signal 2
   ^C
   Error reading OSD configuration from etcd: HTTP request timed out
   ^Z
   [1]+  Stopped                 fio -thread -ioengine=./libfio_vitastor.so -name=test -bs=4M -direct=1 -iodepth=16 -rw=write -etcd=10.115.0.10:2379/v3alpha -image=testimg
   $ kill %1
   
   fio: terminating on signal 15
   $ kill %1
   
   fio: terminating on signal 15
   $ kill %1
   
   fio: terminating on signal 15
   $ kill -9 %1
   ```

- [x] 15.
   ```
   $ sudo ./vitastor-nbd map --image testimg
   /dev/nbd0
   ...
   $ fdisk /dev/nbd0
   
   Welcome to fdisk (util-linux 2.36).
   Changes will remain in memory only, until you decide to write them.
   Be careful before using the write command.
   
   fdisk: cannot open /dev/nbd0: Inappropriate ioctl for device
   $ dd if=/dev/zero of=/dev/nbd0 bs=1M
   dd: error writing '/dev/nbd0': No space left on device
   1+0 records in
   0+0 records out
   0 bytes copied, 0.00171768 s, 0.0 kB/s
   ```

- [x] 16.
   ```
   ... killed both osds
   $ sudo ./vitastor-nbd map --image testimg --foreground &
   /dev/nbd0
   $ fdisk /dev/nbd0
   
   Welcome to fdisk (util-linux 2.36).
   Changes will remain in memory only, until you decide to write them.
   Be careful before using the write command.
   
   fdisk: cannot open /dev/nbd0: Input/output error
   $ dd if=/dev/zero of=/dev/nbd0 bs=1M
   dd: error writing '/dev/nbd0': No space left on device
   1025+0 records in
   1024+0 records out
   1073741824 bytes (1.1 GB, 1.0 GiB) copied, 0.2825 s, 3.8 GB/s
   ```

- [x] 17.
   ```
   $ dd if=testdata of=/dev/nbd0 bs=1M count=1024
   request 0 +2000000 500000056
   reply 500000056 e=-22
   request 2000000 +2000000 500000057
   reply 500000057 e=-22
   request 4000000 +2000000 200000058
   reply 200000058 e=-22
   request 6000000 +2000000 200000059
   reply 200000059 e=-22
   request 8000000 +2000000 20000005a
   reply 20000005a e=-22
   request a000000 +2000000 20000005b
   reply 20000005b e=-22
   request c000000 +2000000 20000005c
   reply 20000005c e=-22
   request e000000 +2000000 20000005d
   reply 20000005d e=-22
   request 10000000 +2000000 200000040
   reply 200000040 e=-22
   request 12000000 +2000000 200000041
   reply 200000041 e=-22
   request 14000000 +2000000 300000042
   reply 300000042 e=-22
   request 16000000 +2000000 300000043
   reply 300000043 e=-22
   request 18000000 +2000000 300000044
   reply 300000044 e=-22
   request 1a000000 +2000000 300000045
   reply 300000045 e=-22
   request 1c000000 +2000000 300000046
   reply 300000046 e=-22
   request 1e000000 +2000000 300000047
   reply 300000047 e=-22
   request 20000000 +2000000 300000048
   reply 300000048 e=-22
   request 22000000 +2000000 300000049
   reply 300000049 e=-22
   request 24000000 +2000000 30000004a
   reply 30000004a e=-22
   request 26000000 +2000000 30000004b
   reply 30000004b e=-22
   request 28000000 +2000000 30000004c
   reply 30000004c e=-22
   request 2a000000 +2000000 30000004d
   reply 30000004d e=-22
   request 2c000000 +2000000 30000004e
   reply 30000004e e=-22
   request 2e000000 +2000000 30000004f
   reply 30000004f e=-22
   request 30000000 +2000000 300000050
   reply 300000050 e=-22
   request 32000000 +2000000 300000051
   reply 300000051 e=-22
   request 34000000 +2000000 300000052
   reply 300000052 e=-22
   request 36000000 +2000000 300000053
   reply 300000053 e=-22
   request 38000000 +2000000 300000054
   reply 300000054 e=-22
   request 3a000000 +2000000 300000055
   reply 300000055 e=-22
   request 3c000000 +2000000 300000056
   reply 300000056 e=-22
   request 3e000000 +2000000 300000057
   reply 300000057 e=-22
   request 0 +1000 300000058
   reply 300000058 e=-22
   request 0 +1000 300000059
   reply 300000059 e=-22
   request 0 +1000 30000005a
   reply 30000005a e=-22
   request 0 +1000 30000005b
   reply 30000005b e=-22
   request 0 +1000 30000005e
   reply 30000005e e=-22
   request 0 +1000 30000005f
   reply 30000005f e=-22
   request 0 +1000 300000040
   reply 300000040 e=-22
   request 0 +1000 300000041
   reply 300000041 e=-22
   request 3000 +1000 300000042
   reply 300000042 e=-22
   request 0 +1000 300000043
   reply 300000043 e=-22
   request 0 +1000 300000044
   reply 300000044 e=-22
   request 3fff0000 +1000 500000060
   reply 500000060 e=-22
   request 3fff0000 +1000 500000061
   reply 500000061 e=-22
   1024+0 records in
   1024+0 records out
   1073741824 bytes (1.1 GB, 1.0 GiB) copied, 0.360875 s, 3.0 GB/s
   $ ./vitastor-cli status
     cluster:
       etcd: 1 / 1 up, 0 B database size
       mon:  0 up
       osd:  2 / 2 up
     
     data:
       raw:   0 B used, 1.8 G / 1.8 G available
       state: 0 B clean
       pools: 0 / 1 active
       pgs:   256 offline
     
     io:
       client: 0 B/s rd, 0 op/s rd, 0 B/s wr, 0 op/s wr
   $ dd if=/dev/nbd0 of=testdata2 bs=1M count=1024
   request 0 +1000 500000055
   reply 500000055 e=-22
   dd: error reading '/dev/nbd0': Input/output error
   0+0 records in
   0+0 records out
   0 bytes copied, 0.000921209 s, 0.0 kB/s
   ```

- [x] 18.
   ```
   $ ./mon-main.js --etcd_address http://localhost:2379/v3alpha
   Waiting to become master
   Became master
   Error: Failed to open etcd watch websocket
       at Mon._die (/home/vladimir/vitastor/mon/mon.js:1770:23)
       at Mon.die (/home/vladimir/vitastor/mon/mon.js:361:32)
       at Mon.start_watcher (/home/vladimir/vitastor/mon/mon.js:560:18)
       at processTicksAndRejections (internal/process/task_queues.js:97:5)
       at async Mon.start (/home/vladimir/vitastor/mon/mon.js:419:9)
   ```

- [x] 19.
   ```
   $ ./mon-main.js --config_path ~/vitastor-bin/src/vitastor.conf 
   Became master
   PG count for pool 1 (testpool) changed from: 0 to 256
   Total space (raw): 0 TB, space efficiency: 100 %
   failed to query etcd: {"error":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","message":"unknown value \"LEASE\" for enum etcdserverpb.Compare_CompareTarget","code":3}
   Error: Cluster connection failed
       at Mon._die (/home/vladimir/vitastor/mon/mon.js:1770:23)
       at Mon.die (/home/vladimir/vitastor/mon/mon.js:361:32)
       at Mon.etcd_call (/home/vladimir/vitastor/mon/mon.js:1764:14)
       at processTicksAndRejections (internal/process/task_queues.js:97:5)
       at async Mon.save_pg_config (/home/vladimir/vitastor/mon/mon.js:1339:21)
       at async Mon.recheck_pgs (/home/vladimir/vitastor/mon/mon.js:1289:13)
       at async Mon.start (/home/vladimir/vitastor/mon/mon.js:430:9)
   ```

- [x] 20.
   ```
   $ ./mon-main.js --config_path ~/vitastor-bin/src/vitastor.conf 
   Became master
   PG count for pool 1 (testpool) changed from: 0 to 256
   Total space (raw): 0 TB, space efficiency: 100 %
   failed to query etcd: {"error":"etcdserver: too many operations in txn request","message":"etcdserver: too many operations in txn request","code":3}
   Error: Cluster connection failed
       at Mon._die (/home/vladimir/vitastor/mon/mon.js:1770:23)
       at Mon.die (/home/vladimir/vitastor/mon/mon.js:361:32)
       at Mon.etcd_call (/home/vladimir/vitastor/mon/mon.js:1764:14)
       at processTicksAndRejections (internal/process/task_queues.js:97:5)
       at async Mon.save_pg_config (/home/vladimir/vitastor/mon/mon.js:1339:21)
       at async Mon.recheck_pgs (/home/vladimir/vitastor/mon/mon.js:1289:13)
       at async Mon.start (/home/vladimir/vitastor/mon/mon.js:430:9)
   ```

- [x] 21.
   ```
   $ PATH=.:$PATH ./vitastor-disk exec-osd /dev/ram0p1
   No RDMA devices found
   [OSD 1] Couldn't initialize RDMA, proceeding with TCP only
   Reading blockstore metadata
   Metadata entries loaded: 0, free blocks: 7546 / 7546
   Reading blockstore journal
   [OSD 1] reporting to etcd at ["http://127.0.0.1:2379/v3alpha"] every 5 seconds
   Journal entries loaded: 0, free journal space: 33550336 bytes (00001000..00001000 is used), free blocks: 7546 / 7546
   [PG 1/1] is starting (0 objects)
   [PG 1/2] is starting (0 objects)
   [PG 1/3] is starting (0 objects)
   [PG 1/5] is starting (0 objects)
   [PG 1/7] is starting (0 objects)
   [PG 1/11] is starting (0 objects)
   [PG 1/13] is starting (0 objects)
   [PG 1/17] is starting (0 objects)
   [PG 1/18] is starting (0 objects)
   [PG 1/22] is starting (0 objects)
   [PG 1/23] is starting (0 objects)
   [PG 1/27] is starting (0 objects)
   [PG 1/28] is starting (0 objects)
   [PG 1/30] is starting (0 objects)
   [PG 1/31] is starting (0 objects)
   [PG 1/32] is starting (0 objects)
   [PG 1/33] is starting (0 objects)
   [PG 1/36] is starting (0 objects)
   [PG 1/37] is starting (0 objects)
   [PG 1/38] is starting (0 objects)
   [PG 1/39] is starting (0 objects)
   [PG 1/40] is starting (0 objects)
   [PG 1/41] is starting (0 objects)
   [PG 1/42] is starting (0 objects)
   [PG 1/43] is starting (0 objects)
   [PG 1/47] is starting (0 objects)
   [PG 1/49] is starting (0 objects)
   [PG 1/50] is starting (0 objects)
   [PG 1/55] is starting (0 objects)
   [PG 1/58] is starting (0 objects)
   [PG 1/61] is starting (0 objects)
   [PG 1/62] is starting (0 objects)
   ^C[OSD 1] Force stopping
   ```

- [x] 22.
   ```
   $ dd if=/dev/nbd0 of=testdata2 bs=1M count=1024
   0+0 records in
   0+0 records out
   0 bytes copied, 0.000104723 s, 0.0 kB/s
   $ sudo ./vitastor-nbd map --image testimg --foreground
   /dev/nbd0
   request 0 +1000 600000042
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 10), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 10), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   terminate called after throwing an instance of 'std::runtime_error'
     what():  epoll_ctl: No such file or directory
   Aborted
   ```

- [x] 23.
   ```
   $ dd if=testdata of=/dev/nbd0 bs=1M count=1024
   1024+0 records in
   1024+0 records out
   1073741824 bytes (1.1 GB, 1.0 GiB) copied, 0.663852 s, 1.6 GB/s
   $ sudo ./vitastor-nbd map --image testimg --foreground
   /dev/nbd0
   request 0 +1000 30000005a
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 10), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 10), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   terminate called after throwing an instance of 'std::runtime_error'
     what():  epoll_ctl: No such file or directory
   Aborted
   ```

- [x] 24.
   ```
   $ sudo ./vitastor-nbd map --image testimg --foreground --peer_connect_interval 1
   request 0 +1000 100000040
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 9), disconnecting peer
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   Ping failed for OSD 1 (client 10), disconnecting peer
   [OSD 0] client 9 disconnected
   primary_read operation failed on OSD 1: retval=-32 (expected 4096), dropping connection
   < restart osd >
   Failed to connect to peer OSD 1 address 192.168.3.22 port 36989: Connection refused
   Failed to connect to peer OSD 1 address 192.168.3.22 port 36989: Connection refused
   ^C
   ```

In this branch I intentionally did not try to match original code style and choice of technologies (like I did in excitoon/dosbox-x#1) for few reasons:
- this branch is a "just for fun" project;
- to distinguish my code and original one instantly;
- it was a bit disgusting (e.g. spaces in `.cpp` and tabs in `CMakeLists.txt`).